### PR TITLE
support flat choices for mongoengine

### DIFF
--- a/mixer/backend/mongoengine.py
+++ b/mixer/backend/mongoengine.py
@@ -152,7 +152,11 @@ class TypeMixer(BaseTypeMixer):
         kwargs = dict()
 
         if field.choices:
-            choices, _ = list(zip(*field.choices))
+            if isinstance(field.choices[0], tuple):
+                choices, _ = list(zip(*field.choices))
+            else:
+                choices = list(field.choices)
+
             return g.gen_choice(choices)
 
         if stype is str:

--- a/tests/test_mongoengine.py
+++ b/tests/test_mongoengine.py
@@ -24,6 +24,8 @@ class Post(Document):
     author = ReferenceField(User)
     category = StringField(choices=(
         ('S', 'Super'), ('M', 'Medium')), required=True)
+    size = StringField(
+        max_length=3, choices=('S', 'M', 'L', 'XL', 'XXL'), required=True)
     tags = ListField(StringField(max_length=30))
     comments = ListField(EmbeddedDocumentField(Comment))
     rating = DecimalField(precision=4, required=True)


### PR DESCRIPTION
Support flat iterable for choices for mongoengine
http://docs.mongoengine.org/en/latest/guide/defining-documents.html#field-arguments
