### PR TITLE
sqlalchemy: fix TypeMixer.get_default for Sequences

### DIFF
--- a/mixer/backend/sqlalchemy.py
+++ b/mixer/backend/sqlalchemy.py
@@ -65,7 +65,7 @@ class TypeMixer(BaseTypeMixer):
         if column.default.is_callable:
             return column.default.arg(target)
 
-        return column.default.arg
+        return getattr(column.default, 'arg', NO_VALUE)
 
     def gen_select(self, target, field_name, field_value):
         """ Select exists value from database.


### PR DESCRIPTION
If a column had a Sequence defined, TypeMixer.get_default thrown an exception because 'arg' attribute doesn't exist on column.default. Return NO_VALUE in such cases.
