### PR TITLE
Fix bug in phone number generator

### DIFF
--- a/mixer/fakers.py
+++ b/mixer/fakers.py
@@ -378,7 +378,7 @@ def get_numerify(template='', symbol='#', **kwargs):
 
     """
     return ''.join(
-        (str(random.randint(0, 10)) if c == '#' else c)
+        (str(random.randint(0, 9)) if c == '#' else c)
         for c in template
     )
 


### PR DESCRIPTION
random.randint generates integer in the range [including upper bound](https://docs.python.org/2/library/random.html#random.randint). 
