### PR TITLE
Fix sqlalchemy using default GenFactory.

### DIFF
--- a/mixer/backend/sqlalchemy.py
+++ b/mixer/backend/sqlalchemy.py
@@ -163,7 +163,7 @@ class TypeMixer(BaseTypeMixer):
             return gen
 
         ftype = type(column.type)
-        stype = self.factory.cls_to_simple(ftype)
+        stype = self.__factory.cls_to_simple(ftype)
 
         if stype is str:
             kwargs['length'] = column.type.length


### PR DESCRIPTION
When using custom `GenFactory` (specified by `Mixer(factory=MyGenFactory)`), the sqlalchemy backend still use the default `GenFactory` in `make_generator`.
