### PR TITLE
Double equals in SELECT condition

### DIFF
--- a/mixer/mix_types.py
+++ b/mixer/mix_types.py
@@ -335,7 +335,7 @@ class Select(Random):
         from mixer.backend.django import mixer
 
         mixer.generate(Role, user=mixer.SELECT(
-            username='test'
+            username=='test'
         ))
 
     """


### PR DESCRIPTION
Only affects a comment, but since that comment gets into the mixer documentation, this messed me up for a while.