### PR TITLE
Fix differing field keys and columns with SQLAlchemy

### DIFF
--- a/mixer/backend/sqlalchemy.py
+++ b/mixer/backend/sqlalchemy.py
@@ -223,9 +223,9 @@ class TypeMixer(BaseTypeMixer):
                 relations |= rel.local_columns
                 yield rel.key, t.Field(rel, rel.key)
 
-        for column in mapper.columns:
+        for key, column in mapper.columns.items():
             if column not in relations:
-                yield column.name, t.Field(column, column.name)
+                yield key, t.Field(column, key)
 
 
 class Mixer(BaseMixer):

--- a/tests/test_sqlalchemy.py
+++ b/tests/test_sqlalchemy.py
@@ -39,7 +39,7 @@ class User(BASE):
     id = Column(Integer, primary_key=True)
     name = Column(String(10), nullable=False)
     role = Column(String(10), default='client', nullable=False)
-    score = Column(SmallInteger, default=50, nullable=False)
+    score = Column(SmallInteger, name='points', default=50, nullable=False)
     updated_at = Column(Boolean)
     created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
     enum = Column(Enum('one', 'two'), nullable=False)


### PR DESCRIPTION
SQLAlchemy differentiates between the key of a field in its class and the name supplied to a column, which indicates its name in the database. Mixer always refers to fields by the name supplied to the column. This makes values end up in the wrong field when both are different, therefore objects can't be saved because the actual field is empty.

This pull request fixes that. I'm not totally certain about the effects of the two `yield`ed values, but from my tests and study of the code, both have to be changed.