### PR TITLE
Fix non-Integer primary keys with SQLAlchemy

### DIFF
--- a/mixer/backend/sqlalchemy.py
+++ b/mixer/backend/sqlalchemy.py
@@ -129,10 +129,13 @@ class TypeMixer(BaseTypeMixer):
         if isinstance(column, RelationshipProperty):
             column = column.local_remote_pairs[0][0]
 
-        return (
-            bool(field.params)
-            or not column.nullable
-            and not (column.autoincrement and column.primary_key))
+        if field.params:
+            return True
+
+        # According to the SQLAlchemy docs, autoincrement "only has an effect for columns which are
+        # Integer derived (i.e. INT, SMALLINT, BIGINT) [and] Part of the primary key [...]".
+        return not column.nullable and not (column.autoincrement and column.primary_key and
+                                            isinstance(column.type, Integer))
 
     def get_value(self, field_name, field_value):
         """ Get `value` as `field_name`.

--- a/tests/test_sqlalchemy.py
+++ b/tests/test_sqlalchemy.py
@@ -51,8 +51,7 @@ class User(BASE):
 class Role(BASE):
     __tablename__ = 'role'
 
-    id = Column(Integer, primary_key=True)
-    name = Column(String(20), nullable=False)
+    name = Column(String(20), primary_key=True)
     user_id = Column(Integer, ForeignKey(User.id), nullable=False)
 
     user = relation(User)


### PR DESCRIPTION
SQLAlchemy always sets `autoincrement=True` for primary key columns. However, according [to the docs](http://docs.sqlalchemy.org/en/rel_0_9/core/metadata.html#column-table-metadata-api), it "only has an effect for columns which are Integer derived (i.e. INT, SMALLINT, BIGINT) [and] Part of the primary key [...]".

`is_required` has to take that into account and state non-Integer primary keys as required, even though they are marked as `autoincrement`.