### PR TITLE
Fix DeprecationWarning when importing GenericForeignKey

### DIFF
--- a/mixer/backend/django.py
+++ b/mixer/backend/django.py
@@ -7,8 +7,12 @@ from types import GeneratorType
 
 import decimal
 from django import VERSION
-from django.contrib.contenttypes.generic import (
-    GenericForeignKey, GenericRelation)
+if VERSION < (1, 8):
+    from django.contrib.contenttypes.generic import (
+        GenericForeignKey, GenericRelation)
+else:
+    from django.contrib.contenttypes.generic.fields import (
+        GenericForeignKey, GenericRelation)
 from django.contrib.contenttypes.models import ContentType
 from django.core.files.base import ContentFile
 from django.core.validators import (


### PR DESCRIPTION
django.contrib.contenttypes.generic is deprecated and will be removed in
Django 1.9. Its contents have been moved to the fields, forms, and admin
submodules of django.contrib.contenttypes.