### PR TITLE
PositiveSmallIntegerField Testing

### DIFF
--- a/mixer/mix_types.py
+++ b/mixer/mix_types.py
@@ -292,7 +292,7 @@ class Random(ServiceValue):
         user = mixer.blend(User, name=mixer.RANDOM('john', 'mike'))
          print user.name  # mike or john
 
-    .. note:: This is also usefull on ORM model generation for randomize fields
+    .. note:: This is also useful on ORM model generation for randomize fields
               with default values (or null).
 
     ::

--- a/tests/test_django.py
+++ b/tests/test_django.py
@@ -40,6 +40,7 @@ def test_fields(mixer):
     assert isinstance(rabbit.object_id, int)
     assert rabbit.object_id >= 0
     assert isinstance(rabbit.error_code, int)
+    assert rabbit.error_code >= 0
     assert rabbit.error_code <= 32767
     assert isinstance(rabbit.created_at, datetime.date)
     assert isinstance(rabbit.updated_at, datetime.datetime)
@@ -294,3 +295,4 @@ def test_small_positive_integer_field_not_too_large(mixer):
     for i in range(4):
         rabbit = mixer.blend(Rabbit)
         assert rabbit.error_code <= 32767
+        assert rabbit.error_code > 0

--- a/tests/test_django.py
+++ b/tests/test_django.py
@@ -40,7 +40,7 @@ def test_fields(mixer):
     assert isinstance(rabbit.object_id, int)
     assert rabbit.object_id >= 0
     assert isinstance(rabbit.error_code, int)
-    assert rabbit.error_code >= 0
+    assert rabbit.error_code <= 32767
     assert isinstance(rabbit.created_at, datetime.date)
     assert isinstance(rabbit.updated_at, datetime.datetime)
     assert isinstance(rabbit.opened_at, datetime.time)

--- a/tests/test_django.py
+++ b/tests/test_django.py
@@ -284,3 +284,13 @@ def test_reload(mixer):
     s1 = mixer.blend(Simple)
     r2, s2 = mixer.reload(r1, s1)
     assert s1 == s2
+
+
+def test_small_positive_integer_field_not_too_large(mixer):
+    """
+    Django 1.10 doc spec for maximum allowable value
+    Multiple assertions to account for sufficient randomization
+    """
+    for i in range(4):
+        rabbit = mixer.blend(Rabbit)
+        assert rabbit.error_code <= 32767


### PR DESCRIPTION
mixer.blend populates PositiveSmallIntegerFields in Django with two high of a value. My current test suite is failing, so I made a new bare assertion in test_fields in test_django. 