### PR TITLE
Replace `fake-factory` with `Faker`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-# requirements
-fake-factory    == 0.5.7
+Faker==0.7.3


### PR DESCRIPTION
It is done due to the following warning: "The fake-factory package will be deprecated on December 15th, 2016" ([source](https://pypi.python.org/pypi/fake-factory)).