### PR TITLE
make_fabric & cls_to_simple fixes

### DIFF
--- a/mixer/backend/sqlalchemy.py
+++ b/mixer/backend/sqlalchemy.py
@@ -177,7 +177,10 @@ class TypeMixer(BaseTypeMixer):
                 column.mapper.class_, mixer=self.__mixer, fake=self.__fake, factory=self.__factory
             ).blend, **kwargs)
 
-        ftype = type(column.type)
+        if column.type.__class__.__name__ == 'TINYINT' and column.type.display_width == 1:
+            ftype = BOOLEAN
+        else:
+            ftype = type(column.type)
 
         # augmented types created with TypeDecorator
         # don't directly inherit from the base types

--- a/mixer/factory.py
+++ b/mixer/factory.py
@@ -141,11 +141,11 @@ class GenFactory(_.with_metaclass(GenFactoryMeta)):
         for type_ in cls.types:
             if type_.__name__ == fcls.__name__:
                 if issubclass(fcls, type_):
-                    ret = type_
+                    ret = cls.types.get(type_)
                     break
             else:
                 if issubclass(fcls, type_):
-                    ret = type_
+                    ret = cls.types.get(type_)
         return ret or (
             fcls if fcls in cls.generators
             else None

--- a/mixer/factory.py
+++ b/mixer/factory.py
@@ -135,7 +135,18 @@ class GenFactory(_.with_metaclass(GenFactoryMeta)):
         :return type: A simple type for generation
 
         """
-        return cls.types.get(fcls) or (
+        if cls.types.get(fcls):
+            return cls.types.get(fcls)
+        ret = None
+        for type_ in cls.types:
+            if type_.__name__ == fcls.__name__:
+                if issubclass(fcls, type_):
+                    ret = type_
+                    break
+            else:
+                if issubclass(fcls, type_):
+                    ret = type_
+        return ret or (
             fcls if fcls in cls.generators
             else None
         )


### PR DESCRIPTION
few fixes to resolve issues with sqlalchemy + MySQL

- `mixer.factory.GenFactory#cls_to_simple` does not handle dialects.

if `fcls` is `<class 'sqlalchemy.dialects.mysql.base.VARCHAR'>` original function returns `None`
with this fix it will return `<class 'sqlalchemy.sql.sqltypes.VARCHAR'>`

- `mixer.backend.sqlalchemy.TypeMixer#make_fabric`
TINYINT(1) should be boolean.
original function generates TINYINT instead of BOOLEAN which may lead to errors

