### PR TITLE
Fixed #81. Warning: Options.vitual_fields deprecated in Django 2.0

### DIFF
--- a/mixer/backend/django.py
+++ b/mixer/backend/django.py
@@ -383,7 +383,7 @@ class TypeMixer(_.with_metaclass(TypeMixerMeta, BaseTypeMixer)):
 
     def __load_fields(self):
 
-        for field in self.__scheme._meta.virtual_fields:
+        for field in self.__scheme._meta.private_fields:
             yield field.name, t.Field(field, field.name)
 
         for field in self.__scheme._meta.fields:


### PR DESCRIPTION
Changed ``virtual_fields`` changed for ``private_fields`` to suppress the deprecation warning .