### PR TITLE
Fix small positive integer field limit

### DIFF
--- a/mixer/_faker.py
+++ b/mixer/_faker.py
@@ -7,6 +7,7 @@ from faker import Factory, Generator
 from faker.config import DEFAULT_LOCALE, AVAILABLE_LOCALES, PROVIDERS
 from faker.providers import BaseProvider
 
+SMALLINT = 32768  # Safe in most databases according to Django docs
 
 GENRES = ('general', 'pop', 'dance', 'traditional', 'rock', 'alternative', 'rap', 'country',
           'jazz', 'gospel', 'latin', 'reggae', 'comedy', 'historical', 'action', 'animation',
@@ -84,11 +85,11 @@ class MixerProvider(BaseProvider):
         """ Get a positive integer. """
         return self.random_int(0, max=max)  # noqa
 
-    def small_integer(self, min=-32768, max=32768):  # noqa
+    def small_integer(self, min=-SMALLINT, max=SMALLINT):  # noqa
         """ Get a positive integer. """
         return self.random_int(min=min, max=max)  # noqa
 
-    def small_positive_integer(self, max=65536):  # noqa
+    def small_positive_integer(self, max=SMALLINT):  # noqa
         """ Get a positive integer. """
         return self.random_int(0, max=max)  # noqa
 

--- a/tests/test_django.py
+++ b/tests/test_django.py
@@ -314,5 +314,5 @@ def test_small_positive_integer_field_not_too_large(mixer):
     """
     for _ in range(4):
         rabbit = mixer.blend(Rabbit)
-        assert rabbit.error_code <= 70000
+        assert rabbit.error_code <= 32767
         assert rabbit.error_code > 0

--- a/tests/test_faker.py
+++ b/tests/test_faker.py
@@ -17,6 +17,7 @@ def test_faker():
 
     assert faker.small_positive_integer()
     assert faker.small_positive_integer() > 0
+    assert faker.small_positive_integer() <= 32767
 
     assert faker.uuid()
 


### PR DESCRIPTION
Upper limit was too high for some database systems. PostgreSQL, for example, has an upper limit of `32767`.

See [PostgreSQL docs (numeric types)](https://www.postgresql.org/docs/9.6/static/datatype-numeric.html)  and [Django docs (PositiveSmallIntegerField)](https://docs.djangoproject.com/en/1.11/ref/models/fields/#positivesmallintegerfield).