### PR TITLE
Fix DeprecationWarning

### DIFF
--- a/mixer/backend/sqlalchemy.py
+++ b/mixer/backend/sqlalchemy.py
@@ -275,7 +275,7 @@ class Mixer(BaseMixer):
         if self.params.get('commit'):
             session = self.params.get('session')
             if not session:
-                LOGGER.warn("'commit' set true but session not initialized.")
+                LOGGER.warning("'commit' set true but session not initialized.")
             else:
                 session.add(target)
                 session.commit()


### PR DESCRIPTION
Fixes a DeprecationWarning warning:

```
 The 'warn' method is deprecated, use 'warning' instead LOGGER.warn("'commit' set true but session not initialized.")
```