### PR TITLE
Add django2 support. Drop django1.9. Update tox and readme

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,10 @@ language: python
 python: 2.7
 
 env:
-    - TOXENV=py27-d9
-    - TOXENV=py35-d9
     - TOXENV=py27-d10
     - TOXENV=py35-d10
+    - TOXENV=py27-d11
+    - TOXENV=py35-d11
     - TOXENV=cov
 
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,32 @@
 language: python
 
-python: 2.7
+python:
+  - 2.7
+  - 3.5
 
 env:
-    - TOXENV=py27-d10
-    - TOXENV=py35-d10
-    - TOXENV=py27-d11
-    - TOXENV=py35-d11
-    - TOXENV=cov
+  - TOXENV=cov
 
-branches:
-    only:
-        - master
-        - develop
+matrix:
+  include:
+    - python: 2.7
+      env: TOXENV=py27-d10
+    - python: 2.7
+      env: TOXENV=py27-d11
+
+    - python: 3.5
+      env: TOXENV=py35-d10
+    - python: 3.5
+      env: TOXENV=py35-d11
+    - python: 3.5
+      env: TOXENV=py35-d20
+
 
 install: pip install --quiet tox
 
-script: tox
+
+script: tox -e ${TOXENV}
+
 
 after_script:
     - if [ $TOXENV == "cov" ]; then

--- a/README.rst
+++ b/README.rst
@@ -58,7 +58,7 @@ Requirements
 
 - python (2.6, 2.7, 3.2, 3.3, 3.4)
 - fake-factory >= 0.5.0
-- Django (1.6, 1.7, 1.8) for Django ORM support;
+- Django (1.10, 1.11, 2.0) for Django ORM support;
 - SQLAlchemy for SQLAlchemy ORM support;
 - Mongoengine for Mongoengine ODM support;
 - Flask-SQLALchemy for SQLAlchemy ORM support and integration as Flask application;
@@ -178,7 +178,7 @@ Mongoengine workflow
 Example usage: ::
 
     from mixer.backend.mongoengine import mixer
-    
+
     class User(Document):
         created_at = DateTimeField(default=datetime.datetime.now)
         email = EmailField(required=True)
@@ -256,7 +256,7 @@ Or you can temporary switch context use the mixer as context manager: ::
     # Will not be save to db
     with mixer.ctx(commit=False):
         user2 = mixer.blend('auth.user')
-        
+
 
 .. _custom:
 

--- a/mixer/backend/django.py
+++ b/mixer/backend/django.py
@@ -189,9 +189,9 @@ class TypeMixer(_.with_metaclass(TypeMixerMeta, BaseTypeMixer)):
 
             # # If the ManyToMany relation has an intermediary model,
             # # the add and remove methods do not exist.
-            if not deffered.scheme.rel.through._meta.auto_created and self.__mixer: # noqa
+            if not deffered.scheme.remote_field.through._meta.auto_created and self.__mixer: # noqa
                 self.__mixer.blend(
-                    deffered.scheme.rel.through, **{
+                    deffered.scheme.remote_field.through, **{
                         deffered.scheme.m2m_field_name(): target,
                         deffered.scheme.m2m_reverse_field_name(): value})
                 continue
@@ -199,7 +199,7 @@ class TypeMixer(_.with_metaclass(TypeMixerMeta, BaseTypeMixer)):
             if not isinstance(value, (list, tuple)):
                 value = [value]
 
-            setattr(target, name, value)
+            getattr(target, name).set(value)
 
         return target
 
@@ -248,7 +248,7 @@ class TypeMixer(_.with_metaclass(TypeMixerMeta, BaseTypeMixer)):
 
         try:
             field = self.__fields[field_name]
-            return field.name, field.scheme.rel.to.objects.filter(**select.params).order_by('?')[0]
+            return field.name, field.scheme.remote_field.model.objects.filter(**select.params).order_by('?')[0]
 
         except Exception:
             raise Exception("Cannot find a value for the field: '{0}'".format(field_name))
@@ -383,7 +383,7 @@ class TypeMixer(_.with_metaclass(TypeMixerMeta, BaseTypeMixer)):
 
     def __load_fields(self):
 
-        for field in self.__scheme._meta.virtual_fields:
+        for field in self.__scheme._meta.private_fields:
             yield field.name, t.Field(field, field.name)
 
         for field in self.__scheme._meta.fields:

--- a/tests/django_app/migrations/0001_initial.py
+++ b/tests/django_app/migrations/0001_initial.py
@@ -32,7 +32,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Customer',
             fields=[
-                ('user_ptr', models.OneToOneField(parent_link=True, auto_created=True, primary_key=True, serialize=False, to=settings.AUTH_USER_MODEL)),
+                ('user_ptr', models.OneToOneField(parent_link=True, auto_created=True, primary_key=True, serialize=False, to=settings.AUTH_USER_MODEL, on_delete=models.CASCADE)),
                 ('name', models.CharField(max_length=100)),
             ],
             options={
@@ -79,7 +79,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('content', models.TextField()),
-                ('client', models.ForeignKey(to='django_app.Client')),
+                ('client', models.ForeignKey(to='django_app.Client', on_delete=models.CASCADE)),
             ],
             options={
             },
@@ -97,7 +97,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='ColorNumber',
             fields=[
-                ('number_ptr', models.OneToOneField(parent_link=True, auto_created=True, primary_key=True, serialize=False, to='django_app.Number')),
+                ('number_ptr', models.OneToOneField(parent_link=True, auto_created=True, primary_key=True, serialize=False, to='django_app.Number', on_delete=models.CASCADE)),
                 ('color', models.CharField(max_length=20)),
             ],
             options={
@@ -148,7 +148,7 @@ class Migration(migrations.Migration):
                 ('object_id', models.PositiveIntegerField()),
                 ('error_code', models.PositiveSmallIntegerField()),
                 ('custom', CustomField(max_length=24)),
-                ('content_type', models.ForeignKey(to='contenttypes.ContentType')),
+                ('content_type', models.ForeignKey(to='contenttypes.ContentType', on_delete=models.CASCADE)),
                 ('binary', models.BinaryField()),
             ],
             options={
@@ -160,7 +160,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('color', models.CharField(max_length=20)),
-                ('hat', models.ForeignKey(to='django_app.Hat')),
+                ('hat', models.ForeignKey(to='django_app.Hat', on_delete=models.CASCADE)),
             ],
             options={
             },
@@ -181,7 +181,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('title', models.CharField(max_length=20)),
-                ('customer', models.ForeignKey(blank=True, to='django_app.Customer', null=True)),
+                ('customer', models.ForeignKey(blank=True, to='django_app.Customer', null=True, on_delete=models.CASCADE)),
                 ('messages', models.ManyToManyField(to='django_app.Message', null=True, blank=True)),
             ],
             options={
@@ -192,8 +192,8 @@ class Migration(migrations.Migration):
             name='Through',
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
-                ('pointas', models.ForeignKey(to='django_app.PointA')),
-                ('pointbs', models.ForeignKey(to='django_app.PointB')),
+                ('pointas', models.ForeignKey(to='django_app.PointA', on_delete=models.CASCADE)),
+                ('pointbs', models.ForeignKey(to='django_app.PointB', on_delete=models.CASCADE)),
             ],
             options={
             },
@@ -202,7 +202,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='rabbit',
             name='one2one',
-            field=models.OneToOneField(to='django_app.Simple'),
+            field=models.OneToOneField(to='django_app.Simple', on_delete=models.CASCADE),
             preserve_default=True,
         ),
         migrations.AddField(
@@ -226,25 +226,25 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='hole',
             name='owner',
-            field=models.ForeignKey(to='django_app.Rabbit'),
+            field=models.ForeignKey(to='django_app.Rabbit', on_delete=models.CASCADE),
             preserve_default=True,
         ),
         migrations.AddField(
             model_name='hat',
             name='owner',
-            field=models.ForeignKey(blank=True, to='django_app.Rabbit', null=True),
+            field=models.ForeignKey(blank=True, to='django_app.Rabbit', null=True, on_delete=models.CASCADE),
             preserve_default=True,
         ),
         migrations.AddField(
             model_name='door',
             name='hole',
-            field=models.ForeignKey(to='django_app.Hole'),
+            field=models.ForeignKey(to='django_app.Hole', on_delete=models.CASCADE),
             preserve_default=True,
         ),
         migrations.AddField(
             model_name='door',
             name='owner',
-            field=models.ForeignKey(blank=True, to='django_app.Rabbit', null=True),
+            field=models.ForeignKey(blank=True, to='django_app.Rabbit', null=True, on_delete=models.CASCADE),
             preserve_default=True,
         ),
     ]

--- a/tests/django_app/models.py
+++ b/tests/django_app/models.py
@@ -43,7 +43,7 @@ class Rabbit(models.Model):
     url = models.URLField(null=True, blank=True, default='')
 
     file_path = models.FilePathField()
-    content_type = models.ForeignKey(ct_models.ContentType)
+    content_type = models.ForeignKey(ct_models.ContentType, on_delete=models.CASCADE)
     object_id = models.PositiveIntegerField()
     error_code = models.PositiveSmallIntegerField()
     custom = CustomField(max_length=24)
@@ -51,7 +51,7 @@ class Rabbit(models.Model):
 
     binary = models.BinaryField()
 
-    one2one = models.OneToOneField('django_app.Simple')
+    one2one = models.OneToOneField('django_app.Simple', on_delete=models.CASCADE)
 
     def save(self, **kwargs):
         """ Custom save. """
@@ -66,7 +66,7 @@ class Rabbit(models.Model):
 class Hole(models.Model):
     title = models.CharField(max_length=16)
     size = models.SmallIntegerField()
-    owner = models.ForeignKey(Rabbit)
+    owner = models.ForeignKey(Rabbit, on_delete=models.CASCADE)
 
     # FIXME compatibility
     rabbits = GenericRelation(Rabbit, **({'related_query_name': 'holes'}))
@@ -79,17 +79,17 @@ class Hat(models.Model):
         ('BL', 'blue'),
     ))
     brend = models.CharField(max_length=10, default='wood')
-    owner = models.ForeignKey(Rabbit, null=True, blank=True)
+    owner = models.ForeignKey(Rabbit, null=True, blank=True, on_delete=models.CASCADE)
 
 
 class Silk(models.Model):
     color = models.CharField(max_length=20)
-    hat = models.ForeignKey(Hat)
+    hat = models.ForeignKey(Hat, on_delete=models.CASCADE)
 
 
 class Door(models.Model):
-    hole = models.ForeignKey(Hole)
-    owner = models.ForeignKey(Rabbit, null=True, blank=True)
+    hole = models.ForeignKey(Hole, on_delete=models.CASCADE)
+    owner = models.ForeignKey(Rabbit, null=True, blank=True, on_delete=models.CASCADE)
     size = models.PositiveIntegerField()
 
 
@@ -113,13 +113,13 @@ class Client(models.Model):
 
 class Message(models.Model):
     content = models.TextField()
-    client = models.ForeignKey(Client)
+    client = models.ForeignKey(Client, on_delete=models.CASCADE)
 
 
 class Tag(models.Model):
     title = models.CharField(max_length=20)
 
-    customer = models.ForeignKey(Customer, blank=True, null=True)
+    customer = models.ForeignKey(Customer, blank=True, null=True, on_delete=models.CASCADE)
     messages = models.ManyToManyField(Message, null=True, blank=True)
 
 
@@ -133,8 +133,8 @@ class PointA(models.Model):
 
 
 class Through(models.Model):
-    pointas = models.ForeignKey(PointA)
-    pointbs = models.ForeignKey(PointB)
+    pointas = models.ForeignKey(PointA, on_delete=models.CASCADE)
+    pointbs = models.ForeignKey(PointB, on_delete=models.CASCADE)
 
 
 class Simple(models.Model):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py27-d9,py35-d9,py27-d10,py35-d10,cov
+envlist=py27-d10,py35-d10,py27-d11,py35-d11,py27-d20,py35-d20,cov
 
 [pytest]
 addopts = -xs
@@ -23,32 +23,46 @@ deps =
     peewee>=2.7.5
     pytest
 
-# Django 1.9
-[testenv:py27-d9]
-basepython = python2.7
-deps =
-    django==1.9.11
-    pony
-    {[testenv]deps}
-
-[testenv:py35-d9]
-basepython = python3.5
-deps =
-    django==1.9.11
-    {[testenv]deps}
-
 # Django 1.10
 [testenv:py27-d10]
 basepython = python2.7
 deps =
-    django==1.10.3
+    django==1.10.8
     pony
     {[testenv]deps}
 
 [testenv:py35-d10]
 basepython = python3.5
 deps =
-    django==1.10.3
+    django==1.10.8
+    {[testenv]deps}
+
+# Django 1.11
+[testenv:py27-d11]
+basepython = python2.7
+deps =
+    django==1.11.8
+    pony
+    {[testenv]deps}
+
+[testenv:py35-d11]
+basepython = python3.5
+deps =
+    django==1.11.8
+    {[testenv]deps}
+
+# Django 2.0
+[testenv:py27-d20]
+basepython = python2.7
+deps =
+    django==2.0.0
+    pony
+    {[testenv]deps}
+
+[testenv:py35-d20]
+basepython = python3.5
+deps =
+    django==2.0.0
     {[testenv]deps}
 
 [testenv:cov]


### PR DESCRIPTION
This commit adds support for Django 2.0, which is now released. It also drops support for Django 1.9.

More work will need to be done with the tox/travis setup if the author would like travis to test django2, as it requires python3 but the current travis config is python2 only.