### PR TITLE
Postgres UUID

### DIFF
--- a/mixer/factory.py
+++ b/mixer/factory.py
@@ -147,6 +147,10 @@ class GenFactory(_.with_metaclass(GenFactoryMeta)):
                 if issubclass(fcls, stype):
                     return cls.types[stype]
 
+        for generator in cls.generators:
+            if isinstance(fcls, generator):
+                return generator
+
         return None
 
     @staticmethod

--- a/mixer/factory.py
+++ b/mixer/factory.py
@@ -129,6 +129,10 @@ class GenFactory(_.with_metaclass(GenFactoryMeta)):
         _.integer_types: int,
     }
 
+    name_hooks = {
+        'UUID': t.UUID,
+    }
+
     @classmethod
     def cls_to_simple(cls, fcls):
         """ Translate class to one of simple base types.
@@ -147,8 +151,8 @@ class GenFactory(_.with_metaclass(GenFactoryMeta)):
                 if issubclass(fcls, stype):
                     return cls.types[stype]
 
-        for generator in cls.generators:
-            if isinstance(fcls, generator):
+        for name, generator in cls.name_hooks.items():
+            if name in fcls.__name__:
                 return generator
 
         return None

--- a/mixer/mix_types.py
+++ b/mixer/mix_types.py
@@ -98,7 +98,10 @@ class UUID:
 
     """ Type for UUIDs. """
 
-    pass
+    def __subclasshook__(cls, other):
+        if hasattr(other, '__name__') and 'UUID' in other.__name__:
+            return True
+        return NotImplemented
 
 
 class Mix(object):

--- a/mixer/mix_types.py
+++ b/mixer/mix_types.py
@@ -98,6 +98,8 @@ class UUID:
 
     """ Type for UUIDs. """
 
+    pass
+
 
 class Mix(object):
 

--- a/mixer/mix_types.py
+++ b/mixer/mix_types.py
@@ -98,11 +98,6 @@ class UUID:
 
     """ Type for UUIDs. """
 
-    def __subclasshook__(cls, other):
-        if hasattr(other, '__name__') and 'UUID' in other.__name__:
-            return True
-        return NotImplemented
-
 
 class Mix(object):
 


### PR DESCRIPTION
Mixer doesn't support [sqlalchemy.dialects.postgresql.UUID](http://docs.sqlalchemy.org/en/latest/dialects/postgresql.html#sqlalchemy.dialects.postgresql.UUID). I'm make simple hotfix for it based on name. I can't make tests for it because mixer's tests uses only in memory sqlite database.