### PR TITLE
Update django.py

### DIFF
--- a/mixer/backend/django.py
+++ b/mixer/backend/django.py
@@ -230,7 +230,11 @@ class TypeMixer(_.with_metaclass(TypeMixerMeta, BaseTypeMixer)):
                 return self._get_value(name, value(), field)
 
             if field:
-                value = field.scheme.to_python(value)
+                try:
+                    _ = int(value)
+                    value = field.scheme.to_python(value)
+                except (TypeError, ValueError):
+                    pass
 
         return name, value
 


### PR DESCRIPTION
This line:
value = field.scheme.to_python(value)
raises an Exception when you upgrade to django 2.1. I don't know why it happens, but this workaround fixed the tests for me :).