### PR TITLE
django 2.1+ support

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,6 +1,6 @@
 [bumpversion]
 commit = True
-current_version = 6.0.1
+current_version = 6.0.1b
 files = mixer/__init__.py
 tag = True
 tag_name = {new_version}

--- a/mixer/__init__.py
+++ b/mixer/__init__.py
@@ -14,7 +14,7 @@ from __future__ import unicode_literals
 # Module information
 # ==================
 
-__version__ = "6.0.1"
+__version__ = "6.0.1b"
 __project__ = "mixer"
 __author__ = "horneds <horneds@gmail.com>"
 __license__ = "BSD"

--- a/mixer/backend/django.py
+++ b/mixer/backend/django.py
@@ -6,6 +6,7 @@ import decimal
 from os import path
 from types import GeneratorType
 
+import django
 from django.apps import apps
 from django.conf import settings
 from django.contrib.contenttypes.fields import GenericForeignKey, GenericRelation   # noqa
@@ -229,7 +230,7 @@ class TypeMixer(_.with_metaclass(TypeMixerMeta, BaseTypeMixer)):
             if callable(value):
                 return self._get_value(name, value(), field)
 
-            if field:
+            if field and not (django.VERSION[0] >= 2 and django.VERSION[1] >= 1):
                 value = field.scheme.to_python(value)
 
         return name, value


### PR DESCRIPTION
supporting django 2.1 for a project

Mixer 6.0.1 version raises an exception while creating FK items in django 2.1:

Traceback (most recent call last):
  File "<console>", line 1, in <module>
  File "/usr/local/lib/python3.6/site-packages/mixer/main.py", line 568, in blend
    return type_mixer.blend(**values)
  File "/usr/local/lib/python3.6/site-packages/mixer/main.py", line 116, in blend
    for name, value in defaults.items()
  File "/usr/local/lib/python3.6/site-packages/mixer/main.py", line 116, in <genexpr>
    for name, value in defaults.items()
  File "/usr/local/lib/python3.6/site-packages/mixer/backend/django.py", line 218, in get_value
    return self._get_value(name, value, field)
  File "/usr/local/lib/python3.6/site-packages/mixer/backend/django.py", line 233, in _get_value
    value = field.scheme.to_python(value)
  File "/usr/local/lib/python3.6/site-packages/django/db/models/fields/related.py", line 874, in to_python
    return self.target_field.to_python(value)
  File "/usr/local/lib/python3.6/site-packages/django/db/models/fields/__init__.py", line 945, in to_python
    params={'value': value},
django.core.exceptions.ValidationError: ["Значение 'Anna Stevens' должно быть целым числом."]

This patch fix it