### PR TITLE
Improve exception when alchemy cannot find fabric for field

### DIFF
--- a/mixer/backend/sqlalchemy.py
+++ b/mixer/backend/sqlalchemy.py
@@ -214,7 +214,7 @@ class TypeMixer(BaseTypeMixer):
         if ftype is Enum:
             return partial(faker.random_element, column.type.enums)
 
-        if stype is None:
+        if fake and stype is None:
             msg = 'cannot make fabric for field {fname} ({ftype})'.format(
                 fname=field_name,
                 ftype=ftype,

--- a/mixer/backend/sqlalchemy.py
+++ b/mixer/backend/sqlalchemy.py
@@ -214,6 +214,13 @@ class TypeMixer(BaseTypeMixer):
         if ftype is Enum:
             return partial(faker.random_element, column.type.enums)
 
+        if stype is None:
+            msg = 'cannot make fabric for field {fname} ({ftype})'.format(
+                fname=field_name,
+                ftype=ftype,
+            )
+            raise NameError(msg)
+
         return super(TypeMixer, self).make_fabric(
             stype, field_name=field_name, fake=fake, kwargs=kwargs)
 


### PR DESCRIPTION
Old error message:

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/mixer/main.py", line 568, in blend
    return type_mixer.blend(**values)
  File "/usr/local/lib/python3.6/site-packages/mixer/main.py", line 116, in blend
    for name, value in defaults.items()
  File "/usr/local/lib/python3.6/site-packages/mixer/main.py", line 116, in <genexpr>
    for name, value in defaults.items()
  File "/usr/local/lib/python3.6/site-packages/mixer/mix_types.py", line 222, in gen_value
    return type_mixer.gen_field(field)
  File "/usr/local/lib/python3.6/site-packages/mixer/main.py", line 193, in gen_field
    return self.gen_value(field.name, field, unique=unique)
  File "/usr/local/lib/python3.6/site-packages/mixer/main.py", line 238, in gen_value
    fab = self.get_fabric(field, field_name, fake=fake)
  File "/usr/local/lib/python3.6/site-packages/mixer/main.py", line 282, in get_fabric
    self.__fabrics[key] = self.make_fabric(field.scheme, field_name, fake)
  File "/usr/local/lib/python3.6/site-packages/mixer/backend/sqlalchemy.py", line 218, in make_fabric
    stype, field_name=field_name, fake=fake, kwargs=kwargs)
  File "/usr/local/lib/python3.6/site-packages/mixer/main.py", line 301, in make_fabric
    factory=self.__factory).blend, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/mixer/main.py", line 50, in __call__
    raise ValueError('Invalid scheme: %s' % backup)
ValueError: Mixer (<class 'platform_alchemy.models.Strategy'>): Invalid scheme: None
```

Reason: Mixer cannot generate fake data for JSONB field.

New error message:
```
NameError: cannot make fabric for field params (<class 'sqlalchemy.dialects.postgresql.json.JSONB'>)
```
