### PR TITLE
Replace deprecated logging.warn with logging.warning

### DIFF
--- a/mixer/markov.py
+++ b/mixer/markov.py
@@ -53,7 +53,7 @@ class MarkovChain(object):
             with open(self.dbFilePath, 'rb') as dbfile:
                 self.db = pickle.load(dbfile)
         except (IOError, ValueError):
-            logging.warn('Database file corrupt or not found, using empty database')
+            logging.warning('Database file corrupt or not found, using empty database')
             self.db = defaultdict(lambda: defaultdict(lambda: 1.0))
 
     def generateDatabase(self, textSample, sentenceSep='[.!?\n]', n=2):
@@ -97,7 +97,7 @@ class MarkovChain(object):
             # It looks like db was written successfully
             return True
         except IOError:
-            logging.warn('Database file could not be written')
+            logging.warning('Database file could not be written')
             return False
 
     def generateString(self):


### PR DESCRIPTION
Replace `logging.warn` (deprecated in [Python 2.7, 2011](https://github.com/python/cpython/commit/04d5bc00a219860c69ea17eaa633d3ab9917409f)) with `logging.warning` (added in [Python 2.3, 2003](https://github.com/python/cpython/commit/6fa635df7aa88ae9fd8b41ae42743341316c90f7)).

* https://docs.python.org/3/library/logging.html#logging.Logger.warning
* https://github.com/python/cpython/issues/57444
