### PR TITLE
docs: Fix a few typos

### DIFF
--- a/mixer/_compat.py
+++ b/mixer/_compat.py
@@ -74,7 +74,7 @@ def with_metaclass(meta, *bases):
 # breaks the __exit__ function in a very peculiar way.  This is currently
 # true for pypy 2.2.1 for instance.  The second level of exception blocks
 # is necessary because pypy seems to forget to check if an exception
-# happend until the next bytecode instruction?
+# happened until the next bytecode instruction?
 BROKEN_PYPY_CTXMGR_EXIT = False
 if hasattr(sys, 'pypy_version_info'):
     class _Mgr(object):

--- a/mixer/auto.py
+++ b/mixer/auto.py
@@ -6,7 +6,7 @@ from . import _compat as _
 
 class MixerProxy(object):
 
-    """ Load mixer for class automaticly.
+    """ Load mixer for class automatically.
 
     ::
 

--- a/mixer/main.py
+++ b/mixer/main.py
@@ -425,7 +425,7 @@ class ProxyMixer:
         raise AttributeError('Use "cycle" only for "blend"')
 
 
-# Support depricated attributes
+# Support deprecated attributes
 class _MetaMixer(type):
 
     FAKE = property(lambda cls: t.Fake())
@@ -479,7 +479,7 @@ class Mixer(_.with_metaclass(_MetaMixer)):
 
     def __getattr__(self, name):
         if name in ['f', 'g', 'fake', 'random', 'mix', 'select']:
-            warnings.warn('"mixer.%s" is depricated, use "mixer.%s" instead.'
+            warnings.warn('"mixer.%s" is deprecated, use "mixer.%s" instead.'
                           % (name, name.upper()), stacklevel=2)
             name = name.upper()
             return getattr(self, name)

--- a/mixer/markov.py
+++ b/mixer/markov.py
@@ -106,7 +106,7 @@ class MarkovChain(object):
 
     def generateStringWithSeed(self, seed):
         """ Generate a "sentence" with the database and a given word """
-        # using str.split here means we're contructing the list in memory
+        # using str.split here means we're constructing the list in memory
         # but as the generated sentence only depends on the last word of the seed
         # I'm assuming seeds tend to be rather short.
         words = seed.split()


### PR DESCRIPTION
There are small typos in:
- mixer/_compat.py
- mixer/auto.py
- mixer/main.py
- mixer/markov.py

Fixes:
- Should read `happened` rather than `happend`.
- Should read `deprecated` rather than `depricated`.
- Should read `constructing` rather than `contructing`.
- Should read `automatically` rather than `automaticly`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md